### PR TITLE
LSP Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 gdscript.wasm
 test.gd
+grammars

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
 .DS_Store
+
 gdscript.wasm
-test.gd
+extension.wasm
 grammars
+test.gd
+
+debug
+target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "zed_gdscript"
+version = "0.0.1"
+edition = "2021"
+publish = false
+license = "MIT"
+
+# [lints]
+# workspace = true
+
+[lib]
+path = "src/gdscript.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+zed_extension_api = "0.0.6"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Zed GDScript
 
 This extension adds support for the [GDScript](https://docs.godotengine.org/en/stable/classes/index.html) language.
+
+## Language Server Protocol
+
+Support for the Godot Language Server Protocol (LSP) is provided via `nc` which is assumed to be in your `PATH`.
+
+The language server is expected to be running on the default ip `127.0.0.1` and port `6005`.

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,0 @@
-{
-  "name": "GDScript",
-  "version": "0.0.2",
-  "authors": ["Mark Brand <mark@grndctrl.com>"],
-  "description": "GDScript language support for Zed",
-  "repository": "https://github.com/grndctrl/zed-gdscript"
-}

--- a/extension.toml
+++ b/extension.toml
@@ -6,6 +6,11 @@ authors = ["Mark Brand <mark@grndctrl.com>"]
 description = "GDScript language support for Zed"
 repository = "https://github.com/grndctrl/zed-gdscript"
 
+[language_servers.gdscript]
+name = "GDScript Language Server"
+language = "GDScript"
+
 [grammars.gdscript]
 repository = "https://github.com/PrestonKnopp/tree-sitter-gdscript"
 commit = "b5dea4d852db65f0872d849c24533eb121e03c76"
+

--- a/extension.toml
+++ b/extension.toml
@@ -1,0 +1,11 @@
+id = "gdscript"
+name = "GDScript"
+version = "0.0.3"
+schema_version = 1
+authors = ["Mark Brand <mark@grndctrl.com>"]
+description = "GDScript language support for Zed"
+repository = "https://github.com/grndctrl/zed-gdscript"
+
+[grammars.gdscript]
+repository = "https://github.com/PrestonKnopp/tree-sitter-gdscript"
+commit = "b5dea4d852db65f0872d849c24533eb121e03c76"

--- a/grammars/gdscript.toml
+++ b/grammars/gdscript.toml
@@ -1,2 +1,0 @@
-repository = "https://github.com/PrestonKnopp/tree-sitter-gdscript"
-commit = "b5dea4d852db65f0872d849c24533eb121e03c76"

--- a/src/gdscript.rs
+++ b/src/gdscript.rs
@@ -1,0 +1,28 @@
+use zed::LanguageServerId;
+use zed_extension_api::{self as zed, Result};
+
+struct GDScriptExtension;
+
+impl zed::Extension for GDScriptExtension {
+    fn new() -> Self {
+        Self
+    }
+
+    fn language_server_command(
+        &mut self,
+        _language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<zed::Command> {
+        let path = worktree
+            .which("nc")
+            .ok_or_else(|| "nc must be installed and available on your $PATH".to_string())?;
+
+        Ok(zed::Command {
+            command: path,
+            args: vec!["127.0.0.1".to_string(), "6005".to_string()],
+            env: Default::default(),
+        })
+    }
+}
+
+zed::register_extension!(GDScriptExtension);


### PR DESCRIPTION
This adds a simple LSP integration using `nc` (necat) which is the same method I use to connect the helix editor to the Godot LSP.

It makes the following assumptions (which could be improved):

* `nc` is in your `PATH`
* The language server is running on `127.0.0.1:6005` (the default)

## Screenshots

![image](https://github.com/grndctrl/zed-gdscript/assets/23323/c2283bda-f600-446f-8343-56bca9d18208)

![image](https://github.com/grndctrl/zed-gdscript/assets/23323/b0dddf3e-1a41-43a6-a33c-11c65d79bb6a)
