### PR TITLE
Add godot resource support

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -13,3 +13,7 @@ language = "GDScript"
 [grammars.gdscript]
 repository = "https://github.com/PrestonKnopp/tree-sitter-gdscript"
 commit = "b5dea4d852db65f0872d849c24533eb121e03c76"
+
+[grammars.godot_resource]
+repository = "https://github.com/PrestonKnopp/tree-sitter-godot-resource"
+commit = "b6ef0768711086a86b3297056f9ffb5cc1d77b4a"

--- a/languages/godot_resource/config.toml
+++ b/languages/godot_resource/config.toml
@@ -1,0 +1,8 @@
+name = "Godot Resource"
+grammar = "godot_resource"
+path_suffixes = ["gdextension", "godot", "import", "tres", "tscn"]
+line_comments = ["; ", ";; "]
+brackets = [
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+]

--- a/languages/godot_resource/highlights.scm
+++ b/languages/godot_resource/highlights.scm
@@ -1,0 +1,29 @@
+(section (identifier) @type.builtin)
+
+(attribute (identifier) @attribute)
+(property (path) @variable.other.member)
+(constructor (identifier) @constructor)
+
+(string) @string
+(integer) @constant.numeric.integer
+(float) @constant.numeric.float
+
+(true) @constant.builtin.boolean
+(false) @constant.builtin.boolean
+
+[
+  "["
+  "]"
+] @tag
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+] @punctuation.bracket
+
+"=" @operator
+
+(ERROR) @error
+(comment) @comment

--- a/languages/godot_resource/injections.scm
+++ b/languages/godot_resource/injections.scm
@@ -1,0 +1,18 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))
+
+; ((section) @injection.content
+;  (#set! injection.language "comment"))
+
+((section
+  (attribute
+    (identifier) @_type
+    (string) @_is_shader)
+  (property
+    (path) @_is_code
+    (string) @injection.content))
+  (#match? @_type "type")
+  (#match? @_is_shader "Shader")
+  (#eq? @_is_code "code")
+  (#set! injection.language "glsl")
+)


### PR DESCRIPTION
This adds support for other Godot resource files like `.tscn` and `.godot`.

I was unsure whether to make this another extension or have it part of this extension, interested in your thoughts.

There's a strange thing currently where if you save one of the resource files it tries to send it to the language server.  I'm not sure if there's a way to prevent this, or maybe it is just another reason to have it as a separate extension.

## Screenshots

![image](https://github.com/grndctrl/zed-gdscript/assets/23323/44965363-30a8-4355-8e5c-7156db0b2756)

![image](https://github.com/grndctrl/zed-gdscript/assets/23323/688215f7-2b3d-4855-a0e9-44fb83fe6ad4)

