### PR TITLE
Fix for indentation/scope

### DIFF
--- a/languages/gdscript/indents.scm
+++ b/languages/gdscript/indents.scm
@@ -1,34 +1,3 @@
-[
-  (if_statement)
-  (for_statement)
-  (while_statement)
-  (match_statement)
-  (pattern_section)
-
-  (function_definition)
-  (constructor_definition)
-  (class_definition)
-  (enum_definition)
-
-  (dictionary (_))
-  (array (_))
-  (setget)
-] @indent
-
-[
-  (if_statement)
-  (for_statement)
-  (while_statement)
-  (match_statement)
-  (pattern_section)
-
-  (function_definition)
-  (class_definition)
-] @extend
-
-[
-  (return_statement)
-  (break_statement)
-  (continue_statement)
-  (pass_statement)
-] @extend.prevent-once
+(_ "[" "]" @end) @indent
+(_ "{" "}" @end) @indent
+(_ "(" ")" @end) @indent


### PR DESCRIPTION
The current implementation of `indents.scm` interferes with indentation, this fix simply implements `indents.scm` the same way that it is done for the python extension.