### PR TITLE
Fixes Issue #10 by taking some code from python's implementation in zed.

### DIFF
--- a/languages/gdscript/config.toml
+++ b/languages/gdscript/config.toml
@@ -2,7 +2,19 @@ name = "GDScript"
 grammar = "gdscript"
 path_suffixes = ["gd"]
 line_comments = ["# ", "## "]
+autoclose_before = ";:.,=}])>"
 brackets = [
-    { start = "[", end = "]", close = true, newline = true },
-    { start = "(", end = ")", close = true, newline = true },
+     { start = "{", end = "}", close = true, newline = true },
+     { start = "[", end = "]", close = true, newline = true },
+     { start = "(", end = ")", close = true, newline = true },
+     { start = "\"", end = "\"", close = true, newline = false, not_in = [
+          "string",
+     ] },
+     { start = "'", end = "'", close = true, newline = false, not_in = [
+          "string",
+     ] },
 ]
+
+auto_indent_using_last_non_empty_line = false
+increase_indent_pattern = ":\\s*$"
+decrease_indent_pattern = "^\\s*(else|elif|except|finally)\\b.*:"

--- a/languages/gdscript/indents.scm
+++ b/languages/gdscript/indents.scm
@@ -1,34 +1,3 @@
-[
-  (if_statement)
-  (for_statement)
-  (while_statement)
-  (match_statement)
-  (pattern_section)
-
-  (function_definition)
-  (constructor_definition)
-  (class_definition)
-  (enum_definition)
-
-  (dictionary (_))
-  (array (_))
-  (setget)
-] @indent
-
-[
-  (if_statement)
-  (for_statement)
-  (while_statement)
-  (match_statement)
-  (pattern_section)
-
-  (function_definition)
-  (class_definition)
-] @extend
-
-[
-  (return_statement)
-  (break_statement)
-  (continue_statement)
-  (pass_statement)
-] @extend.prevent-once
+(_ "[" "]" @end) @indent
+(_ "{" "}" @end) @indent
+(_ "(" ")" @end) @indentn


### PR DESCRIPTION
This patch should fix Issue #10. It steals code from zed's implementation of python. The end result is working auto-indentation for functions,  if statements (including elifs and elses), match statements, for loops and while loops. From my own testing, it works very well.