### PR TITLE
Add initial debugging support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [lib]
 path = "src/gdscript.rs"
-crate-type = [ "cdylib",]
+crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.6.0"

--- a/README.md
+++ b/README.md
@@ -82,6 +82,32 @@ Optionally, if you have [`godot-gdscript-toolkit`](https://github.com/Scony/godo
 }
 ```
 
+## Debugging
+
+> [!NOTE]
+> At the time of writing this, debugging will not work when using Godot 4.4. It's confirmed to work in Godot 4.3 and 4.5, however.
+
+The extension provides a debug adapter that allows debugging GDScript code. To be able to do this, create `.zed/debug.json` file in the root of your workspace with the following content:
+
+```json
+[
+  {
+    "adapter": "godot",
+    "label": "Godot (Launch)",
+    "request": "launch"
+  },
+  {
+    "adapter": "godot",
+    "label": "Godot (Attach)",
+    "request": "attach"
+  }
+]
+```
+
+This will add 2 debug tasks: `Godot (Launch)` will launch a new debugging session, while `Godot (Attach)` will try to attach to an existing one. To run these tasks, press `F4`, then select the desired task from the menu.
+
+Complete list of options can be found in [`debug_adapter_schemas/godot.json`](debug_adapter_schemas/godot.json). Zed will also suggest possible options through autocompletion when editing the `debug.json` file.
+
 ## Contributing
 
 ## Editing .scm files

--- a/debug_adapter_schemas/godot.json
+++ b/debug_adapter_schemas/godot.json
@@ -1,0 +1,33 @@
+{
+  "type": "object",
+  "properties": {
+    "request": {
+      "type": "string",
+      "enum": ["launch", "attach"],
+      "default": "launch"
+    },
+    "project": {
+      "type": "string",
+      "description": "Path to the Godot project"
+    },
+    "platform": {
+      "type": "string",
+      "enum": ["host", "android", "web"],
+      "description": "Platform that the project will run on",
+      "default": "host"
+    },
+    "device": {
+      "type": "integer",
+      "description": "Android device ID"
+    },
+    "host": {
+      "type": "string",
+      "default": "127.0.0.1"
+    },
+    "port": {
+      "type": "integer",
+      "default": 6006
+    }
+  },
+  "required": ["request"]
+}

--- a/extension.toml
+++ b/extension.toml
@@ -2,7 +2,12 @@ id = "gdscript"
 name = "GDScript"
 version = "0.5.0"
 schema_version = 1
-authors = [ "Mark Brand <mark@grndctrl.com>", "Richard Taylor <moomerman@gmail.com>", "Radu Gafita <radugaf@gmail.com>", "Nathan Lovato <nathan@gdquest.com>",]
+authors = [
+    "Mark Brand <mark@grndctrl.com>",
+    "Richard Taylor <moomerman@gmail.com>",
+    "Radu Gafita <radugaf@gmail.com>",
+    "Nathan Lovato <nathan@gdquest.com>",
+]
 description = "Godot game engine support for Zed. Adds support for GDScript, Godot Resources (.tres, .tscn), and GDShader files."
 repository = "https://github.com/grndctrl/zed-gdscript"
 
@@ -21,3 +26,5 @@ commit = "2ffb90de47417018651fc3b970e5f6b67214dc9d"
 [grammars.gdshader]
 repository = "https://github.com/GodOfAvacyn/tree-sitter-gdshader"
 commit = "ffd9f958df13cae04593781d7d2562295a872455"
+
+[debug_adapters.godot]

--- a/languages/gdscript/config.toml
+++ b/languages/gdscript/config.toml
@@ -13,3 +13,4 @@ auto_indent_using_last_non_empty_line = false
 increase_indent_pattern = ":\\s*$"
 autoclose_before = ":.,}])>"
 hard_tabs = true
+debuggers = ["godot"]

--- a/src/gdscript.rs
+++ b/src/gdscript.rs
@@ -1,5 +1,11 @@
-use zed::LanguageServerId;
-use zed_extension_api::{self as zed, Result};
+use std::net::Ipv4Addr;
+
+use zed_extension_api::{
+    self as zed,
+    serde_json::{self, Value},
+    DebugAdapterBinary, Result, StartDebuggingRequestArguments,
+    StartDebuggingRequestArgumentsRequest, TcpArguments,
+};
 
 struct GDScriptExtension;
 
@@ -10,7 +16,7 @@ impl zed::Extension for GDScriptExtension {
 
     fn language_server_command(
         &mut self,
-        _language_server_id: &LanguageServerId,
+        _language_server_id: &zed::LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
         let (os, _) = zed::current_platform();
@@ -23,7 +29,7 @@ impl zed::Extension for GDScriptExtension {
         let path = nc_command
             .ok_or_else(|| "nc or ncat must be installed and available on your PATH".to_string())?;
 
-        let lsp_settings = zed::settings::LspSettings::for_worktree("gdscript", &worktree);
+        let lsp_settings = zed::settings::LspSettings::for_worktree("gdscript", worktree);
         let mut args = None;
 
         if let Ok(lsp_settings) = lsp_settings {
@@ -37,6 +43,64 @@ impl zed::Extension for GDScriptExtension {
             args: args.unwrap_or(vec!["127.0.0.1".to_string(), "6005".to_string()]),
             env: Default::default(),
         })
+    }
+
+    fn get_dap_binary(
+        &mut self,
+        adapter_name: String,
+        config: zed::DebugTaskDefinition,
+        _user_provided_debug_adapter_path: Option<String>,
+        _worktree: &zed::Worktree,
+    ) -> Result<DebugAdapterBinary, String> {
+        let configuration = serde_json::from_str::<serde_json::Value>(&config.config)
+            .map_err(|e| format!("Error parsing the config: {e}"))?;
+
+        let request = self.dap_request_kind(adapter_name, configuration.clone())?;
+
+        let host = configuration
+            .get("host")
+            .and_then(|host| host.as_str().and_then(|host| host.parse().ok()))
+            .unwrap_or(Ipv4Addr::new(127, 0, 0, 1))
+            .to_bits();
+
+        let port = configuration
+            .get("port")
+            .and_then(|port| port.as_u64())
+            .unwrap_or(6006) as u16;
+
+        Ok(DebugAdapterBinary {
+            command: None,
+            arguments: vec![],
+            envs: Default::default(),
+            cwd: None,
+
+            connection: Some(TcpArguments {
+                host,
+                port,
+                timeout: None,
+            }),
+
+            request_args: StartDebuggingRequestArguments {
+                configuration: config.config,
+                request,
+            },
+        })
+    }
+
+    fn dap_request_kind(
+        &mut self,
+        _adapter_name: String,
+        value: Value,
+    ) -> Result<StartDebuggingRequestArgumentsRequest, String> {
+        value
+            .get("request")
+            .and_then(|v| v.as_str())
+            .ok_or("`request` was not specified".into())
+            .and_then(|request| match request {
+                "launch" => Ok(StartDebuggingRequestArgumentsRequest::Launch),
+                "attach" => Ok(StartDebuggingRequestArgumentsRequest::Attach),
+                _ => Err("`request` must be either `launch` or `attach`".into()),
+            })
     }
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable): #41

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

Adds initial debugging support. You can either launch a new debugging session or attach to an existing one.

Some caveats:
- Won't work in Godot 4.4, unless Zed fixes the issue on their side, see https://github.com/zed-industries/zed/issues/34054. However, it should work fine in 4.3 and 4.5 beta 4 (or later).
- There doesn't seem to be a way for the extension to provide preconfigured debug tasks, so users will have to create them manually.
- It can only launch the main scene, I couldn't find a way to launch the currently edited scene. I will look into it more. Upd: this will be possible if/when https://github.com/godotengine/godot/pull/109637 is merged.

Debug tasks are defined in `.zed/debug.json` in the root of your project. Here is an example of 2 debug tasks, the first one launches a new session and the second one attaches to a running one:

```json
[
  {
    "adapter": "godot",
    "label": "Godot (Launch)",
    "request": "launch"
  },
  {
    "adapter": "godot",
    "label": "Godot (Attach)",
    "request": "attach"
  }
]
```

To launch a task press `F4`, then select a task in the debug section.

~~If `request` is omitted, then it will default to `launch`.~~ If your Godot project is not in the workspace root, then you will have to set `project` property manually:

```json
{
    "adapter": "godot",
    "label": "Godot (Launch)",
    "request": "launch",
    "project": "$ZED_WORKTREE_ROOT/project"
}
```

Other possible options are defined in `debug_adapter_schemas/godot.json`:
- `platform` (string): The platform the the project will run on. Possible values: `host` (default), `android`, `web`. When running on android, users will also have to specify `device` property.
- `device` (integer): I am not familiar with android stuff, but this is some kind of device ID.
- `host` (string): IP of the Godot's debug adapter. Default: `127.0.0.1`.
- `port` (integer): Port that Godot's debug adapter listens to. Default: `6006`.

**Does this PR introduce a breaking change?**

No

## New feature or change ##


**What is the current behavior?**

No debugging support.

**What is the new behavior?**

Yes debugging support.

**Other information**

TODO:

- [x] Make host and port configurable
- [x] Add debugging section to readme that explains debug tasks

Closes https://github.com/GDQuest/zed-gdscript/issues/41