### PR TITLE
Fix identifiers in `binary_operator` being marked as types

### DIFF
--- a/languages/gdscript/highlights.scm
+++ b/languages/gdscript/highlights.scm
@@ -29,8 +29,6 @@
 (string) @string
 
 (type) @type
-(expression_statement (array (identifier) @type))
-(binary_operator (identifier) @type)
 (enum_definition (name) @type.enum)
 (enumerator (identifier) @type.enum.variant)
 [


### PR DESCRIPTION
This PR fixes identifiers in `binary_operator` nodes being wrongly marked as types. Same thing with arrays in `expression_statement`

Before:
<img width="139" height="88" alt="Screenshot_20251008_213911" src="https://github.com/user-attachments/assets/710b1ed1-b649-44e9-afa5-4cf2ce93b56e" />

After:
<img width="148" height="90" alt="Screenshot_20251008_213834" src="https://github.com/user-attachments/assets/3b9ecc52-fb48-4cab-b0b3-67f5c0b5868f" />
