### PR TITLE
Fix built-in types not being marked as types

### DIFF
--- a/languages/gdscript/highlights.scm
+++ b/languages/gdscript/highlights.scm
@@ -40,9 +40,9 @@
 (attribute
   (identifier)
   (identifier) @variable.other.member)
-(attribute
-  (identifier) @type.builtin
-  (#match? @type.builtin "^(AABB|Array|Basis|bool|Callable|Color|Dictionary|float|int|NodePath|Object|Packed(Byte|Color|String)Array|PackedFloat(32|64)Array|PackedInt(32|64)Array|PackedVector(2|3)Array|Plane|Projection|Quaternion|Rect2([i]{0,1})|RID|Signal|String|StringName|Transform(2|3)D|Variant|Vector(2|3|4)([i]{0,1}))$"))
+
+((identifier) @type.builtin
+  (#match? @type.builtin "^(AABB|Array|Basis|bool|Callable|Color|Dictionary|float|int|NodePath|Object|Packed(Byte|Color|String)Array|PackedFloat(32|64)Array|PackedInt(32|64)Array|PackedVector(2|3|4)Array|Plane|Projection|Quaternion|Rect2([i]{0,1})|RID|Signal|String|StringName|Transform(2|3)D|Variant|Vector(2|3|4)([i]{0,1}))$"))
 
 [
   (string_name)


### PR DESCRIPTION
My previous PR revealed an issue where built-in Godot types weren't being highlighted (e.g. when used in if statements). This is because the query only matches identifiers that are children of the `attribute` node, which seems like a mistake.

I also added missing `PackedVector4Array` type to the list.

Before:
<img width="180" height="100" alt="Screenshot_20251008_221922" src="https://github.com/user-attachments/assets/7a58774e-916f-4d5b-b811-70dd9d3b5104" />

After:
<img width="180" height="92" alt="Screenshot_20251008_221952" src="https://github.com/user-attachments/assets/f0725c28-1378-4b0d-80c0-1f9436ce443c" />
