### PR TITLE
Fix capitalized identifiers not being marked as constants

### DIFF
--- a/languages/gdscript/highlights.scm
+++ b/languages/gdscript/highlights.scm
@@ -1,10 +1,4 @@
-; Identifier naming conventions
-
-(
-  (identifier) @constant
-  (#match? @constant "^[A-Z][A-Z\\d_]+$"))
-
-; class
+; Class
 (class_name_statement (name) @type)
 (class_definition (name) @type)
 
@@ -154,3 +148,9 @@
   "get"
   "await"
 ] @keyword
+
+; Identifier naming conventions
+; This needs to be at the very end in order to override earlier queries
+(
+  (identifier) @constant
+  (#match? @constant "^[A-Z][A-Z\\d_]+$"))


### PR DESCRIPTION
Before:
<img width="235" height="61" alt="Screenshot_20251008_231511" src="https://github.com/user-attachments/assets/286c490c-208a-48ca-9d9a-311220aee7da" />

After:
<img width="232" height="62" alt="Screenshot_20251008_231541" src="https://github.com/user-attachments/assets/9388a1e2-3389-468a-85a9-24d5ce76d8c2" />
