### PR TITLE
Add syntax highlighting for regions

### DIFF
--- a/languages/gdscript/highlights.scm
+++ b/languages/gdscript/highlights.scm
@@ -20,6 +20,10 @@
 
 ;; Literals
 (comment) @comment
+[
+  (region_start)
+  (region_end)
+] @comment.doc
 (string) @string
 
 (type) @type


### PR DESCRIPTION
Now that regions have their own nodes, we need to handle them separately.

I decided to mark them as `@comment.doc` to separate them a little from regular comments, similar to how Godot's internal code editor does it.

<img width="354" height="275" alt="Screenshot_20251009_132322" src="https://github.com/user-attachments/assets/763ad004-6117-4836-b9d7-1cc1df80c0a2" />
