### PR TITLE
Improvements to syntax highlighting

### DIFF
--- a/languages/gdscript/highlights.scm
+++ b/languages/gdscript/highlights.scm
@@ -65,6 +65,7 @@
   "+"
   "-"
   "*"
+  "**"
   "/"
   "%"
   "=="
@@ -135,6 +136,9 @@
   "get"
   "await"
 ] @keyword
+
+((identifier) @keyword
+  (#match? @keyword "^self$"))
 
 ; Identifier naming conventions
 ; This needs to be at the very end in order to override earlier queries


### PR DESCRIPTION
- Mark `self` as keyword (Godot's code editor does the same)
- Add `**` operator