### PR TITLE
Highlight property access

### DIFF
--- a/languages/gdscript/highlights.scm
+++ b/languages/gdscript/highlights.scm
@@ -36,7 +36,7 @@
 (variable_statement (identifier) @variable)
 (attribute
   (identifier)
-  (identifier) @variable)
+  (identifier) @property)
 
 ((identifier) @type
   (#match? @type "^(bool|float|int)$"))
@@ -138,7 +138,7 @@
 ] @keyword
 
 ((identifier) @keyword
-  (#match? @keyword "^self$"))
+  (#match? @keyword "^(self|super)$"))
 
 ; Identifier naming conventions
 ; This needs to be at the very end in order to override earlier queries


### PR DESCRIPTION
Highlights properties when accessing them with a dot.

Before:

<img width="975" height="134" alt="Screenshot_20251016_102734" src="https://github.com/user-attachments/assets/7a641523-57e0-4da2-8ec2-1d36991aad24" />

After:

<img width="968" height="133" alt="Screenshot_20251016_102856" src="https://github.com/user-attachments/assets/e90383b8-b5ff-4197-a3b4-a972e018213d" />

Also adds `super` as a keyword.