### PR TITLE
DAP: Add `playArgs` and `scene` properties to the schema

### DIFF
--- a/debug_adapter_schemas/godot.json
+++ b/debug_adapter_schemas/godot.json
@@ -27,6 +27,15 @@
     "port": {
       "type": "integer",
       "default": 6006
+    },
+    "playArgs": {
+      "type": "array",
+      "description": "Command line arguments to pass to instance(s)"
+    },
+    "scene": {
+      "type": "string",
+      "default": "main",
+      "description": "Possible values: main, current, or path to a custom scene"
     }
   },
   "required": ["request"]


### PR DESCRIPTION

- This PR adds descriptions for the new `playArgs` and `scene` debugger options that were added in https://github.com/godotengine/godot/pull/109637

I had to shorten the description for `scene`, otherwise it wouldn't fit in the auto completion UI.