### PR TITLE
feat: add gdshaderinc extension to the GDShader grammar

### DIFF
--- a/languages/gdshader/config.toml
+++ b/languages/gdshader/config.toml
@@ -1,6 +1,6 @@
 name = "GDShader"
 grammar = "gdshader"
-path_suffixes = ["gdshader"]
+path_suffixes = ["gdshader", "gdshaderinc"]
 line_comments = ["// "]
 block_comment = ["/* ", " */"]
 brackets = [


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [X] The commit message follows our guidelines.
- For bug fixes and features:
    - [X] You tested the changes.

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

Add `.gdshaderinc` as a valid file extension for a GDShader file.

**Does this PR introduce a breaking change?**

No.

## New feature or change ##


**What is the current behavior?** 

`.gdshaderinc` files do not have syntax highlighting.

**What is the new behavior?**

`.gdshaderinc` files have syntax highlighting.