### PR TITLE
Fix highlighting for GDScript constructors

### DIFF
--- a/data/parsing_test.gd
+++ b/data/parsing_test.gd
@@ -9,3 +9,8 @@ func _init() -> void:
 func _process(delta: float) -> void:
 	position += velocity * delta
 	rotation = velocity.angle()
+
+
+class InnerClass extends RefCounted:
+	func _init(arg: int) -> void:
+		pass

--- a/languages/gdscript/highlights.scm
+++ b/languages/gdscript/highlights.scm
@@ -18,13 +18,16 @@
 ; Function definitions
 (function_definition
   name: (name) @function.definition)
-; Constructor definition
+; Constructor definition (tree-sitter doesn't return a name capture for it)
+(constructor_definition
+    "_init" @constructor)
+; Constructor definition fallback (when tree-sitter doesn't report it correctly, e.g. in inner classes).
 (function_definition
     name: (name) @constructor
     (#eq? @constructor "_init"))
-; Untyped function parameter defintiion: a in func foo(a)
+; Untyped function parameter definition: a in func foo(a)
 (parameters (identifier) @variable.parameter)
-; Typed function parameter defition: b in func foo(b: int)
+; Typed function parameter definition: b in func foo(b: int)
 (parameters
   (typed_parameter
     . (identifier) @variable.parameter))


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


**What kind of change does this PR introduce?**

Fixes highlighting for the `_init` constructor in GDScript files.


**Does this PR introduce a breaking change?**

No.


## New feature or change ##


**What is the current behavior?** 

With the current published version of the extension, the `_init` method of main script classes is not highlighted correctly. In fact, it is not highlighted at all, defaulting to some fallback color that doesn't get overridden by any of the highlighting rules in the theme. This is not the case for inner classes though.

The issue is that the GDScript tree-sitter has a dedicated capture, `constructor_definition`, for the main script constructor, whereas we expect it to be a regular `function_definition` which we can match the name against. The fact that inner classes do not produce `constructor_definition` is the reason why they are not affected and is probably a bug in the tree-sitter.


**What is the new behavior?**

I've added a new rule for `constructor_definition` so it is matched for highlighting. Interestingly, this capture was already supported in some other schemes. Alas, `constructor_definition` doesn't have a name sub-capture, so the new rule has to match against a literal, otherwise highlighting spills into "punctuation" around the method.

Also extended the test script and fixed a couple of typos nearby.