### PR TITLE
Highlight setget methods and punctuation in GDScript

### DIFF
--- a/data/parsing_test.gd
+++ b/data/parsing_test.gd
@@ -2,6 +2,17 @@
 class_name MyClass extends Sprite2D
 
 var property := Vector2(480, -480)
+var array_property: Array[Vector2] = []
+
+@export var exported_property: int = 42:
+	get:
+		return 4
+	set(value):
+		exported_property = value
+var setget_property: float = 3.2:
+	get = get_setget_property,
+	set = set_setget_property
+
 
 func _init() -> void:
 	pass

--- a/languages/gdscript/highlights.scm
+++ b/languages/gdscript/highlights.scm
@@ -15,6 +15,12 @@
 (base_call (identifier) @function.builtin)
 (call (identifier) @function)
 
+; Setget
+(setget
+    get: (getter) @function.method)
+(setget
+    set: (setter) @function.method)
+
 ; Function definitions
 (function_definition
   name: (name) @function.definition)
@@ -134,6 +140,22 @@
   "**="
   ":" ; for consistency (to make :type= same as :=)
 ] @operator
+
+; Delimiters
+[
+  "."
+  ","
+  ";"
+] @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
 
 ; Keywords
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


**What kind of change does this PR introduce?**

Improves highlighting of setget methods and punctuation symbols in GDScript. These are generally unrelated changes, but I made them at the same time and didn't see the point of making two PRs.

**Does this PR introduce a breaking change?**

No.

## New feature or change ##

**What is the current behavior?** 

Currently class methods assigned as setters and getters are not highlighted at all.

Additionally, punctuation (such as period signs) and brackets do not get marked up for highlighting either. While the lack of highlighting makes the latter gray under normal circumstances, inside of type hints brackets inherit the color of the surrounding context, leading to types like `Array[SubType]` being highlighted as one whole thing.

<img width="1088" height="777" alt="before" src="https://github.com/user-attachments/assets/9d8bee56-d2fe-4e87-8dbb-eb02fcfb92b7" />


**What is the new behavior?**

This change adds markup to properly highlight setget methods as class methods, and also introduces markup for punctuation and brackets.

(Colors are from my own theme and don't represent the exact visibility of these elements; the markup used is specific for these elements.)

<img width="1088" height="777" alt="after" src="https://github.com/user-attachments/assets/24337728-90d5-4b66-bdb1-00a918a7de72" />
