### PR TITLE
Improve highlighting around self/super

### DIFF
--- a/data/parsing_test.gd
+++ b/data/parsing_test.gd
@@ -15,11 +15,19 @@ var setget_property: float = 3.2:
 
 
 func _init() -> void:
-	pass
+	super()
+	super.other()
+	self.property.x = 20
+	method_call(self)
+
 
 func _process(delta: float) -> void:
 	position += velocity * delta
 	rotation = velocity.angle()
+
+
+func _not_implemented() -> void:
+	pass
 
 
 class InnerClass extends RefCounted:

--- a/languages/gdscript/highlights.scm
+++ b/languages/gdscript/highlights.scm
@@ -3,6 +3,9 @@
 ; but a = 10 has 'a matching nothing.
 ; This is to keep consistency, and is like 'text_editor/theme/highlighting/text_color' in Godot Editor Settings
 (identifier) @variable
+; Self reference in class.
+((identifier) @variable.builtin
+  (#eq? @variable.builtin "self"))
 
 
 ; Class
@@ -12,8 +15,16 @@
 
 ; Function calls
 (attribute_call (identifier) @function.method)
-(base_call (identifier) @function.builtin)
+(base_call (identifier) @function.method)
 (call (identifier) @function)
+; Super calls have two forms:
+; - super() to call this method's parent implementation,
+; - super.other() to call another method's parent implementation.
+((identifier) @function.builtin
+    (#eq? @function.builtin "super"))
+(call (identifier) @function.builtin
+    (#eq? @function.builtin "super"))
+
 
 ; Setget
 (setget
@@ -220,9 +231,6 @@
   "class_name"
   "extends"
 ] @keyword
-
-((identifier) @variable.language
-  (#match? @variable.language "^(self|super)$"))
 
 ; Identifier naming conventions
 ; This needs to be at the very end in order to override earlier queries


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


**What kind of change does this PR introduce?**

This changeset improves highlighting for special GDScript identifiers `super` and `self`, at least for the cases now added to the test script. Previous implementation was unsatisfactory in terms of catching some of these cases, and on top of that, since #76, the highlighting was using a tag not present in current Zed themes, at least official ones (`@variable.language`).

-----

As an extra, this change moves highlighting for `base_call` from `@function.builtin` to the basic `@function.method`. Base calls aren't really any different from method calls, and the built-in highlighting is better reserved for things like `super` here.

Also, I don't think it's possible to get `base_call` from the tree-sitter here, since it targets specifically the Godot 3 version of these calls, before `super` was introduced. I wasn't able to find a way to get it at least. Here's an example from the tree-sitter docs, and this syntax is invalid in Godot 4's version of GDScript:

```
=====================================
Base Calls
=====================================

.hello()
var x = .hello()
var x = hello(.hello())

---

(source
  (expression_statement (base_call (identifier) (arguments)))
  (variable_statement (name) (base_call (identifier) (arguments)))
  (variable_statement
    (name)
    (call (identifier) (arguments (base_call (identifier) (arguments))))))

=====================================
```

PS. I've made these changes some weeks ago at this point, so memory is a bit murky about their completeness. But I've been using my local dev version of the extension this whole time and that's probably sufficient testing.