### PR TITLE
Add Netcat installation procedure for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ You can install Netcat from your package manager:
 - On Ubuntu/Debian Linux: `sudo apt install netcat`.
 - On Fedora Linux: `sudo dnf install nmap-ncat`.
 - On macOS: `brew install netcat`.
+- On Windows:
+  - Netcat is integrated with [NMap](https://nmap.org/download#windows)
+  - Download and run the latest stable release self-installer
+  - Ensure Nmap Core files, Register Nmap Path, Npcap and Ncat are selected from the list of options
+  - When prompted, accept and install Npcap
 
 Note that the installed program might be called `nc` or `ncat`, depending on your operating system and package manager (short for netcat). The extension will try to find either of them in your system PATH.
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,10 @@ You can install Netcat from your package manager:
 - On Ubuntu/Debian Linux: `sudo apt install netcat`.
 - On Fedora Linux: `sudo dnf install nmap-ncat`.
 - On macOS: `brew install netcat`.
-- On Windows:
-  - Netcat is integrated with [NMap](https://nmap.org/download#windows)
-  - Download and run the latest stable release self-installer
-  - Ensure Nmap Core files, Register Nmap Path, Npcap and Ncat are selected from the list of options
-  - When prompted, accept and install Npcap
+- On Windows, Netcat is integrated with [NMap](https://nmap.org/download#windows). To install it:
+  1. Download and run the latest stable release self-installer
+  2. Ensure Nmap Core files, Register Nmap Path, Npcap and Ncat are selected from the list of options
+  3. When prompted, accept and install Npcap
 
 Note that the installed program might be called `nc` or `ncat`, depending on your operating system and package manager (short for netcat). The extension will try to find either of them in your system PATH.
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [X] The commit message follows our guidelines.
- For bug fixes and features:
    - [X] You tested the changes. (Tested on Windows 11 Home 25H2 26200.8655) 

**What kind of change does this PR introduce?**

This PR introduces steps for installing Netcat onto Windows devices.


**Does this PR introduce a breaking change?**

No, it only involves changes to README.md.


## New feature or change ##

Added a series of steps for installing Netcat onto Windows devices using the stable NMap installer.
Steps for installing the dependency were previously missing for Windows users. 
These were the steps I followed to get the dependency installed on my machine. 
The extension works correctly after opening a project in Godot.



